### PR TITLE
feat:Add search post by title feature in command palette

### DIFF
--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -4,6 +4,7 @@
 import {
   HomeIcon,
   LightBulbIcon,
+  MagnifyingGlassIcon,
   MoonIcon,
   SunIcon,
 } from '@heroicons/react/24/outline';
@@ -44,6 +45,16 @@ export default function CommandPalette({ children }: Props) {
         name: '頁面',
         priority: Priority.HIGH,
       },
+    },
+    // Search section
+    // - Search posts
+    {
+      id: 'search-posts',
+      name: '文章',
+      keywords:
+        'search find posts writing words blog articles thoughts 搜尋 尋找 文章 寫作 部落格',
+      icon: <MagnifyingGlassIcon className="h-6 w-6" />,
+      section: '搜尋',
     },
     // Operation section
     // - Theme toggle

--- a/src/components/CommandPalette/getCommandPalettePosts.ts
+++ b/src/components/CommandPalette/getCommandPalettePosts.ts
@@ -1,0 +1,16 @@
+import { allPostsNewToOld } from '@/lib/contentLayerAdapter';
+
+export type PostForCommandPalette = {
+  slug: string;
+  title: string;
+  path: string;
+};
+
+export const getCommandPalettePosts = (): PostForCommandPalette[] => {
+  const commandPalettePosts = allPostsNewToOld.map((post) => ({
+    slug: post.slug,
+    title: post.title,
+    path: post.path,
+  }));
+  return commandPalettePosts;
+};

--- a/src/components/CommandPalette/useCommandPalettePostActions.tsx
+++ b/src/components/CommandPalette/useCommandPalettePostActions.tsx
@@ -1,0 +1,21 @@
+import { useRegisterActions } from 'kbar';
+import { useRouter } from 'next/router';
+
+import { PostForCommandPalette } from './getCommandPalettePosts';
+
+export const useCommandPalettePostActions = (
+  posts: PostForCommandPalette[]
+): void => {
+  const router = useRouter();
+
+  useRegisterActions(
+    posts.map((post) => ({
+      id: post.slug,
+      name: post.title,
+      perform: () => router.push(post.path),
+      section: '搜尋文章',
+      parent: 'search-posts',
+    })),
+    []
+  );
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,6 +2,11 @@ import type { NextPage } from 'next';
 import { GetStaticProps } from 'next';
 import { ArticleJsonLd } from 'next-seo';
 
+import {
+  getCommandPalettePosts,
+  PostForCommandPalette,
+} from '@/components/CommandPalette/getCommandPalettePosts';
+import { useCommandPalettePostActions } from '@/components/CommandPalette/useCommandPalettePostActions';
 import PostList, { PostForPostList } from '@/components/PostList';
 import { siteConfigs } from '@/configs/siteConfigs';
 import { allPostsNewToOld } from '@/lib/contentLayerAdapter';
@@ -11,9 +16,12 @@ type PostForIndexPage = PostForPostList;
 
 type Props = {
   posts: PostForIndexPage[];
+  commandPalettePosts: PostForCommandPalette[];
 };
 
 export const getStaticProps: GetStaticProps<Props> = () => {
+  const commandPalettePosts = getCommandPalettePosts();
+
   const posts = allPostsNewToOld.map((post) => ({
     slug: post.slug,
     date: post.date,
@@ -24,10 +32,12 @@ export const getStaticProps: GetStaticProps<Props> = () => {
 
   generateRSS();
 
-  return { props: { posts } };
+  return { props: { posts, commandPalettePosts } };
 };
 
-const Home: NextPage<Props> = ({ posts }) => {
+const Home: NextPage<Props> = ({ posts, commandPalettePosts }) => {
+  useCommandPalettePostActions(commandPalettePosts);
+
   return (
     <div>
       <ArticleJsonLd

--- a/src/pages/posts/[slug].tsx
+++ b/src/pages/posts/[slug].tsx
@@ -2,6 +2,11 @@ import type { GetStaticPaths, GetStaticProps, NextPage } from 'next';
 import { useMDXComponent } from 'next-contentlayer/hooks';
 import { ArticleJsonLd, NextSeo } from 'next-seo';
 
+import {
+  getCommandPalettePosts,
+  PostForCommandPalette,
+} from '@/components/CommandPalette/getCommandPalettePosts';
+import { useCommandPalettePostActions } from '@/components/CommandPalette/useCommandPalettePostActions';
 import PostLayout, {
   PostForPostLayout,
   RelatedPostForPostLayout,
@@ -26,6 +31,7 @@ type Props = {
   post: PostForPostPage;
   prevPost: RelatedPostForPostLayout;
   nextPost: RelatedPostForPostLayout;
+  commandPalettePosts: PostForCommandPalette[];
 };
 
 export const getStaticPaths: GetStaticPaths = () => {
@@ -37,6 +43,8 @@ export const getStaticPaths: GetStaticPaths = () => {
 };
 
 export const getStaticProps: GetStaticProps<Props> = ({ params }) => {
+  const commandPalettePosts = getCommandPalettePosts();
+
   const postIndex = allPostsNewToOld.findIndex(
     (post) => post.slug === params?.slug
   );
@@ -76,11 +84,19 @@ export const getStaticProps: GetStaticProps<Props> = ({ params }) => {
       post,
       prevPost,
       nextPost,
+      commandPalettePosts,
     },
   };
 };
 
-const PostPage: NextPage<Props> = ({ post, prevPost, nextPost }) => {
+const PostPage: NextPage<Props> = ({
+  post,
+  prevPost,
+  nextPost,
+  commandPalettePosts,
+}) => {
+  useCommandPalettePostActions(commandPalettePosts);
+
   const {
     description,
     title,


### PR DESCRIPTION
Known bug:
in local dev mode, after change page, post options in command palette will be duplicated, but in production it is fine, reason unknown

NOTE:
The reason why we have to put logics in every pages is because the limitation of kbar, contentlayer, and Next.js Contentlayer allPosts import must put inside getStaticProps, and currently Next.js do not support shared getStaticProps in _app.tsx, so we can only duplicate logic in every pages, and use kbar's useRegisterActions to dynamically add post options in every page

Ref
https://easonchang.com/posts/kbar-post-search